### PR TITLE
Sitemap plugin: Parse template_pages and write them in sitemap

### DIFF
--- a/sitemap/sitemap.py
+++ b/sitemap/sitemap.py
@@ -227,6 +227,19 @@ class SitemapGenerator(object):
                                 save_as=standard_page_url)
                 self.write_url(fake, fd)
 
+            # add template pages
+            for path, template_page_url in self.context['TEMPLATE_PAGES'].iteritems():
+
+                # don't add duplicate entry for index page
+                if template_page_url == 'index.html':
+                    continue
+
+                fake = FakePage(status='published',
+                                date=self.now,
+                                url=template_page_url,
+                                save_as=template_page_url)
+                self.write_url(fake, fd)
+
             for page in pages:
                 self.write_url(page, fd)
 


### PR DESCRIPTION
As a developer I would like my template pages to be written in sitemap.xml

NOTE: I initially thought that Pelican will parse template pages as `contents.Page`, but it seems that's not true.

Let me know if you prefer me to implement this in a different way.
